### PR TITLE
Add more state management hooks to GameProvider

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,13 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 
 import "./App.css";
 import Routing from "./routes/index";
-import { GameProvider } from "./components/GameProvider";
 
-// Defining the App component
 function App() {
 	return (
-		// Wrapping the entire app inside GameProvider so that all components have access to the game state
-		<GameProvider test-id="game-context">
+		<>
 			<Routing />
-		</GameProvider>
+		</>
 	);
 }
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
+import React from "react";
 import App from "./App";
-import { GameContext } from "./components/GameProvider";
+import { GameContextProvider } from "./components/GameProvider";
 
 /*
 test('renders learn react link', () => {
@@ -9,14 +10,20 @@ test('renders learn react link', () => {
   expect(linkElement).toBeInTheDocument();
 });
 */
+
 // Test suite for App component
 describe("App component", () => {
 	// Test case: App renders without crashing
 	test("renders without crashing", () => {
 		// Render the App component
-		const { container } = render(<App />);
+		const { container } = render(
+			<React.StrictMode>
+				<GameContextProvider>
+					<App />
+				</GameContextProvider>
+			</React.StrictMode>,
+		);
 
-		// Check if the App component rendered
 		expect(container).toBeTruthy();
 	});
 });

--- a/src/components/GameProvider.js
+++ b/src/components/GameProvider.js
@@ -2,7 +2,7 @@ import React from "react";
 
 export const GameContext = React.createContext();
 
-export const GameProvider = ({ children }) => {
+export const GameContextProvider = ({ children }) => {
 	const [gameState, setGameState] = React.useState({
 		// numPlayers: represents the number of players in a game.
 		numPlayers: 0,
@@ -14,9 +14,112 @@ export const GameProvider = ({ children }) => {
 		// 4. role: The player's role in the game.
 		players: {},
 	});
+	const goodRoles = {
+		Merlin: "Merlin",
+		Percival: "Percival",
+		Servant: "Loyal Servant of Arthur",
+		Troublemaker: "Troublemaker",
+		Cleric: "Cleric",
+		UntrustworthyServant: "Untrustworthy Servant",
+		GoodLancelot: "Good Lancelot",
+		GoodSorcerer: "Good Sorcerer",
+		GoodRogue: "Good Rogue",
+		SeniorMessenger: "Senior Messenger",
+		JuniorMessenger: "Junior Messenger",
+	};
+
+	const evilRoles = {
+		Mordred: "Mordred",
+		Morgana: "Morgana",
+		Oberon: "Oberon",
+		Assassin: "Assassin",
+		Minion: "Minion of Mordred",
+		Trickster: "Trickster",
+		Lunatic: "Lunatic",
+		Brute: "Brute",
+		Revealer: "Revealer",
+		EvilLancelot: "Evil Lancelot",
+		EvilSorcerer: "Evil Sorcerer",
+		EvilRogue: "Evil Rogue",
+		EvilMessenger: "Evil Messenger",
+	};
+	const createPlayer = (userName, displayName) => {
+		if (!userName) {
+			console.error("Invalid userName");
+			return;
+		}
+		if (!displayName) {
+			console.error("Invalid displayName");
+			return;
+		}
+		return {
+			userName: userName,
+			displayName: displayName,
+			index: 0,
+			role: "",
+		};
+	};
+
+	const addPlayer = (player) => {
+		if (player && player.userName && player.displayName) {
+			setGameState((prevState) => ({
+				numPlayers: prevState.numPlayers + 1,
+				players: {
+					...prevState.players,
+					[player.userName]: player,
+				},
+			}));
+		} else {
+			console.error("Invalid player object or properties");
+		}
+	};
+
+	const addPlayerRole = (userName, role) => {
+		if (userName && role && (!!goodRoles[role] || !!evilRoles[role])) {
+			setGameState((prevState) => ({
+				numPlayers: prevState.numPlayers,
+				players: {
+					...prevState.players,
+					[userName]: {
+						...prevState.players[userName],
+						role: role,
+					},
+				},
+			}));
+		} else {
+			console.error("Invalid userName or role");
+		}
+	};
+
+	const addPlayerIndex = (userName, index) => {
+		if (userName && index && index >= 1) {
+			setGameState((prevState) => ({
+				numPlayers: prevState.numPlayers,
+				players: {
+					...prevState.players,
+					[userName]: {
+						...prevState.players[userName],
+						index: index,
+					},
+				},
+			}));
+		} else {
+			console.error("Invalid userName or index");
+		}
+	};
 
 	return (
-		<GameContext.Provider value={{ gameState, setGameState }}>
+		<GameContext.Provider
+			value={{
+				gameState,
+				addPlayer,
+				createPlayer,
+				addPlayerRole,
+				addPlayerIndex,
+				goodRoles,
+				evilRoles,
+			}}
+		>
 			{children}
 		</GameContext.Provider>
 	);

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,14 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
+import { GameContextProvider } from "./components/GameProvider";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
 	<React.StrictMode>
-		<App />
+		<GameContextProvider>
+			<App />
+		</GameContextProvider>
 	</React.StrictMode>,
 );
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,6 +1,9 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
+import { GameContext } from "../components/GameProvider.js";
 
 const HomePage = () => {
+	//Add the GameContext hooks and state you need to the below line
+	const {} = useContext(GameContext);
 	return (
 		<div>
 			<h3>HomePage</h3>

--- a/src/pages/TestStatePage.jsx
+++ b/src/pages/TestStatePage.jsx
@@ -1,0 +1,74 @@
+import React, { useContext, useState } from "react";
+import { GameContext } from "../components/GameProvider.js";
+
+const TestState = () => {
+	/*
+    The following code snippets is here because they are primarily an example of how to access 
+    manipulate the game state in the game context provider. We won't use this page in the final product.
+    */
+
+	const {
+		gameState,
+		addPlayer,
+		createPlayer,
+		addPlayerRole,
+		addPlayerIndex,
+	} = useContext(GameContext);
+
+	const [name, setName] = useState("");
+	const [userName, setUserName] = useState("");
+	const [role, setRole] = useState("");
+
+	const handleSubmit = (event) => {
+		event.preventDefault();
+		const playerObj = createPlayer(userName, name, 1, role);
+		addPlayer(playerObj);
+		addPlayerRole(playerObj.userName, role);
+		addPlayerIndex(playerObj.userName, 1);
+		setName("");
+		setUserName("");
+		setRole("");
+	};
+
+	return (
+		<div>
+			<h3>Test State Page</h3>
+			<p>
+				Current number of players:{" "}
+				{JSON.stringify(gameState.numPlayers)}
+			</p>
+			Current roster of players:{" "}
+			<pre>
+				{gameState.players != {}
+					? JSON.stringify(gameState.players, null, 2)
+					: ""}
+			</pre>
+			<form onSubmit={handleSubmit}>
+				<input
+					type="text"
+					value={name}
+					onChange={(e) => setName(e.target.value)}
+					placeholder="Name"
+					required
+				/>
+				<input
+					type="text"
+					value={userName}
+					onChange={(e) => setUserName(e.target.value)}
+					placeholder="Username"
+					required
+				/>
+				<input
+					type="text"
+					value={role}
+					onChange={(e) => setRole(e.target.value)}
+					placeholder="Role"
+					required
+				/>
+				<button type="submit">Add Player</button>
+			</form>
+		</div>
+	);
+};
+
+export default TestState;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -7,11 +7,13 @@ import {
 } from "react-router-dom";
 import HomePage from "../pages/HomePage";
 import NotFound from "../pages/NotFound";
+import TestState from "../pages/TestStatePage";
 const Routing = (props) => {
 	return (
 		<Router>
 			<Routes>
 				<Route exact path="/" element={<HomePage />} />
+				<Route exact path="/test" element={<TestState />} />
 				<Route exact path="*" element={<NotFound />} />
 			</Routes>
 		</Router>


### PR DESCRIPTION
Add more state management hooks to GameProvider and added examples of how to use them to new TestStatePage.jsx.

I also moved the context provider to wrap around the app component instead of existing inside the app component so if we need to access the game's state in the app we can do that now.

After code review to test, run the solution and add "/test" to the end of the URL to see the new test page. Make sure things work as you may expect
